### PR TITLE
Add task list for deleting all default VPCs in an account

### DIFF
--- a/tasks/delete_default_vpcs.yml
+++ b/tasks/delete_default_vpcs.yml
@@ -16,13 +16,9 @@
 
 - name: list default VPCs
   ec2_vpc_net_facts:
-    profile:        '{{ aws_profile }}'
-    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
-    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
-    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
-
     filters:
       isDefault: 'true'
+    profile: '{{ aws_profile }}'
     region: '{{ _aws_vpc_region }}'
   loop: '{{ _aws_vpc_regions }}'
   loop_control:
@@ -68,13 +64,9 @@
 
 - name: get default VPC subnet facts
   ec2_vpc_subnet_facts:
-    profile:        '{{ aws_profile }}'
-    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
-    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
-    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
-
     filters:
       vpc-id: '{{ _aws_vpc_default_vpc.vpc_id }}'
+    profile: '{{ aws_profile }}'
     region: '{{ _aws_vpc_default_vpc.region }}'
   loop: '{{ _aws_vpc_default_vpcs }}'
   loop_control:
@@ -106,10 +98,8 @@
 
 - name: delete default VPC subnets
   ec2_vpc_subnet:
-    profile: '{{ aws_profile }}'
-    # this Ansible module supports automatic role assumption
-
     cidr: '{{ _aws_vpc_default_vpc_subnet.cidr_block }}'
+    profile: '{{ aws_profile }}'
     region: '{{ _aws_vpc_default_vpc_subnet.region }}'
     state: absent
     vpc_id: '{{ _aws_vpc_default_vpc_subnet.vpc_id }}'
@@ -122,11 +112,7 @@
 
 - name: set default VPC "Name" tag for reference by ec2_vpc_net module
   ec2_tag:
-    profile:        '{{ aws_profile }}'
-    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
-    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
-    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
-
+    profile: '{{ aws_profile }}'
     region: '{{ _aws_vpc_default_vpc.region }}'
     resource: '{{ _aws_vpc_default_vpc.vpc_id }}'
     tags:
@@ -138,13 +124,9 @@
 
 - name: delete default VPCs
   ec2_vpc_net:
-    profile:        '{{ aws_profile }}'
-    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
-    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
-    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
-
     cidr_block: '{{ _aws_vpc_default_vpc.cidr_block }}'
     name: default
+    profile: '{{ aws_profile }}'
     region: '{{ _aws_vpc_default_vpc.region }}'
     state: absent
   loop: '{{ _aws_vpc_default_vpcs }}'

--- a/tasks/delete_default_vpcs.yml
+++ b/tasks/delete_default_vpcs.yml
@@ -1,0 +1,153 @@
+---
+
+- name: list all regions
+  aws_region_facts:
+    profile: '{{ aws_profile }}'
+  register: _aws_vpc_region_facts
+
+- name: set region list fact
+  set_fact:
+    _aws_vpc_regions: >-
+      {{
+        _aws_vpc_region_facts
+        | json_query("regions[*].region_name")
+        | sort
+      }}
+
+- name: list default VPCs
+  ec2_vpc_net_facts:
+    profile:        '{{ aws_profile }}'
+    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
+    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
+    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
+
+    filters:
+      isDefault: 'true'
+    region: '{{ _aws_vpc_region }}'
+  loop: '{{ _aws_vpc_regions }}'
+  loop_control:
+    loop_var: _aws_vpc_region
+  register: _aws_vpc_default_vpcs_facts
+
+- name: initialize default VPC list fact
+  set_fact:
+    _aws_vpc_default_vpcs: []
+
+- name: set default VPC list fact
+  set_fact:
+    _aws_vpc_default_vpcs: >-
+      {{
+        _aws_vpc_default_vpcs
+        | union([{
+                  'cidr_block': _aws_vpc_region.vpcs[0].cidr_block,
+                  'region':     _aws_vpc_region._aws_vpc_region,
+                  'vpc_id':     _aws_vpc_region.vpcs[0].vpc_id
+               }])
+      }}
+  loop: '{{ _aws_vpc_default_vpcs_facts.results }}'
+  loop_control:
+    label: '{{ _aws_vpc_region._aws_vpc_region }}'
+    loop_var: _aws_vpc_region
+  when: _aws_vpc_region.vpcs != []
+
+- name: delete default VPC Internet gateways
+  ec2_vpc_igw:
+    profile:        '{{ aws_profile }}'
+    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
+    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
+    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
+
+    region: '{{ _aws_vpc_default_vpc.region }}'
+    state: absent
+    vpc_id: '{{ _aws_vpc_default_vpc.vpc_id }}'
+  loop: '{{ _aws_vpc_default_vpcs }}'
+  loop_control:
+    label: '{{ _aws_vpc_default_vpc.region }}'
+    loop_var: _aws_vpc_default_vpc
+  register: _aws_vpc_igw
+
+- name: get default VPC subnet facts
+  ec2_vpc_subnet_facts:
+    profile:        '{{ aws_profile }}'
+    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
+    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
+    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
+
+    filters:
+      vpc-id: '{{ _aws_vpc_default_vpc.vpc_id }}'
+    region: '{{ _aws_vpc_default_vpc.region }}'
+  loop: '{{ _aws_vpc_default_vpcs }}'
+  loop_control:
+    label: '{{ _aws_vpc_default_vpc.region }}'
+    loop_var: _aws_vpc_default_vpc
+  register: _aws_vpc_default_vpc_subnet_facts
+
+- name: initialize default VPC subnet list fact
+  set_fact:
+    _aws_vpc_default_vpc_subnets: []
+
+- name: set default VPC subnet list fact
+  set_fact:
+    _aws_vpc_default_vpc_subnets: >-
+      {{
+        _aws_vpc_default_vpc_subnets
+        | union(
+            _aws_vpc_default_vpc_subnet_fact
+            | json_query("subnets[*].{cidr_block: cidr_block, 
+                                      region: '" + region + "',
+                                      vpc_id: vpc_id}"))
+      }}
+  loop: '{{ _aws_vpc_default_vpc_subnet_facts.results }}'
+  loop_control:
+    label: '{{ region }}'
+    loop_var: _aws_vpc_default_vpc_subnet_fact
+  vars:
+    region: '{{ _aws_vpc_default_vpc_subnet_fact._aws_vpc_default_vpc.region }}'
+
+- name: delete default VPC subnets
+  ec2_vpc_subnet:
+    profile: '{{ aws_profile }}'
+    # this Ansible module supports automatic role assumption
+
+    cidr: '{{ _aws_vpc_default_vpc_subnet.cidr_block }}'
+    region: '{{ _aws_vpc_default_vpc_subnet.region }}'
+    state: absent
+    vpc_id: '{{ _aws_vpc_default_vpc_subnet.vpc_id }}'
+  loop: '{{ _aws_vpc_default_vpc_subnets }}'
+  loop_control:
+    label: >-
+      {{ _aws_vpc_default_vpc_subnet.region }},
+      {{ _aws_vpc_default_vpc_subnet.cidr_block }}
+    loop_var: _aws_vpc_default_vpc_subnet
+
+- name: set default VPC "Name" tag for reference by ec2_vpc_net module
+  ec2_tag:
+    profile:        '{{ aws_profile }}'
+    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
+    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
+    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
+
+    region: '{{ _aws_vpc_default_vpc.region }}'
+    resource: '{{ _aws_vpc_default_vpc.vpc_id }}'
+    tags:
+      Name: default
+  loop: '{{ _aws_vpc_default_vpcs }}'
+  loop_control:
+    label: '{{ _aws_vpc_default_vpc.region }}'
+    loop_var: _aws_vpc_default_vpc
+
+- name: delete default VPCs
+  ec2_vpc_net:
+    profile:        '{{ aws_profile }}'
+    aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
+    aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
+    security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
+
+    cidr_block: '{{ _aws_vpc_default_vpc.cidr_block }}'
+    name: default
+    region: '{{ _aws_vpc_default_vpc.region }}'
+    state: absent
+  loop: '{{ _aws_vpc_default_vpcs }}'
+  loop_control:
+    label: '{{ _aws_vpc_default_vpc.region }}'
+    loop_var: _aws_vpc_default_vpc


### PR DESCRIPTION
This task file enumerates default VPCs and deletes them, along with their dependent entities. VPCs that are not in the out-of-the-box default state will fail to be deleted in some cases, since this only accounts for the out-of-the-box state in deciding what to delete.

You need to have https://github.com/h3biomed/h3-ansible/pull/39 applied to the parent repository in order for this to work, and then you can run `make aws-vpc vpc=VPC_NAME task=delete_default_vpcs`, which will delete the default VPC in each AWS region in the same account as `VPC_NAME` is in. (That is kind of confusing, so I'm going to see if I can find some way to make the target an account instead of a VPC.)

This _shouldn't_ be dangerous since you can't delete a VPC when it still has things in it, but this is probably worth a multi-person review in any case.