### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,8 @@
         }}#vpcs:filter=^{{ aws_vpc_name }}$
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-vpc</b> on
@@ -49,7 +50,8 @@
 - include_tasks: sgs.yml
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-vpc</b> on

--- a/tasks/nat_gateway.yml
+++ b/tasks/nat_gateway.yml
@@ -66,7 +66,8 @@
       when: _aws_vpc_nat_elastic_ip is defined
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           disassociated
@@ -107,7 +108,8 @@
       when: _aws_vpc_existing_nat_gateway.result | length == 0
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           created a <a href="https://console.aws.amazon.com/vpc/home?region={{

--- a/tasks/rtbs.yml
+++ b/tasks/rtbs.yml
@@ -13,7 +13,8 @@
   when: aws_vpc_subnets.public is defined
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       configured the <a href="https://console.aws.amazon.com/vpc/home?region={{
@@ -40,7 +41,8 @@
   when: aws_vpc_subnets.private is defined
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       configured the <a href="https://console.aws.amazon.com/vpc/home?region={{

--- a/tasks/sgs.yml
+++ b/tasks/sgs.yml
@@ -58,7 +58,8 @@
          | difference(_aws_vpc_new_sgs) | sort }}
 
 - name: call optional notifier for newly-created security groups
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       created new security
@@ -73,7 +74,8 @@
     _aws_vpc_new_sgs
 
 - name: call optional notifier for modified security groups
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       modified security
@@ -88,7 +90,8 @@
     _aws_vpc_modified_sgs
 
 - name: call optional notifier for untracked security groups
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message:
     attachments:

--- a/tasks/subnets.yml
+++ b/tasks/subnets.yml
@@ -15,7 +15,8 @@
   register: _aws_vpc_subnet
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       configured <a href="https://console.aws.amazon.com/vpc/home?region={{

--- a/tasks/vpc.yml
+++ b/tasks/vpc.yml
@@ -14,7 +14,8 @@
     _aws_vpc_id: '{{ _aws_vpc_configuration.vpc.id }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
      message: >
        created <a href="{{ _aws_vpc_url }}">VPC {{ aws_vpc_name }}</a>

--- a/tasks/vpces.yml
+++ b/tasks/vpces.yml
@@ -15,7 +15,8 @@
     _aws_vpc_private_route_table.route_table is defined
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       added an <a href="https://console.aws.amazon.com/vpc/home?region={{


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.