### PR TITLE
Switch from deprecated alias of aws_vpc_dhcp_option in submodule defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-aws_vpc_dhcp_options:
+aws_vpc_dhcp_option:
   domain_name: ec2.internal
   dns_servers: AmazonProvidedDNS
 


### PR DESCRIPTION
I missed this in my first pass.  
I also found that this will need to be changed in https://github.com/h3biomed/h3-ansible/blob/master/group_vars/aws-vpcs/dhcp_options.yml as well, I'll submit a PR for the root repository once this one is approved and merged.